### PR TITLE
Gateway support the partly done Status label in the responses

### DIFF
--- a/src/main/lombok/eu/coinform/gateway/controller/CheckController.java
+++ b/src/main/lombok/eu/coinform/gateway/controller/CheckController.java
@@ -88,7 +88,7 @@ public class CheckController {
                 new QueryResponse(queryObject.getQueryId(), QueryResponse.Status.in_progress, null, new LinkedHashMap<>(), new LinkedHashMap<>())).join();
         QueryResponse queryResponse = responsePair.getValue();
         log.trace("{}: got query response {}", System.currentTimeMillis() - start, queryResponse);
-        if (queryResponse.getStatus() == QueryResponse.Status.done) {
+        if (queryResponse.getStatus() == QueryResponse.Status.done || queryResponse.getStatus() == QueryResponse.Status.partly_done) {
             //todo: We're ignoring the modules. Some logic for when to send them queries must be made.
             // Like if the cache is older than some threshold it is handled as a new query.
             // The information of results directly from cache must also be saved/sent somewhere for the modules to know.

--- a/src/main/lombok/eu/coinform/gateway/service/ResponseHandler.java
+++ b/src/main/lombok/eu/coinform/gateway/service/ResponseHandler.java
@@ -82,6 +82,8 @@ public class ResponseHandler {
             Object responsesList =  ruleEngineResult.get("module_labels");
             if (responsesList != null && ((Map) responsesList).keySet().size() == moduleList.size()) {
                 qr.setStatus(QueryResponse.Status.done);
+            } else {
+                qr.setStatus(QueryResponse.Status.partly_done);
             }
 
             qr.getResponse().put("rule_engine", ruleEngineResult);


### PR DESCRIPTION
API compliance fix. Making the Gateway set the QueryResponse status to 'partly_done' when some of the modules responses have been processed but not all of them.