### PR TITLE
Fixes issue #37

### DIFF
--- a/src/main/lombok/eu/coinform/gateway/controller/UserController.java
+++ b/src/main/lombok/eu/coinform/gateway/controller/UserController.java
@@ -180,20 +180,23 @@ public class UserController {
         SecurityContext ctx = SecurityContextHolder.getContext();
         Authentication authentication = ctx.getAuthentication();
 
-        Long userid = (Long) authentication.getPrincipal();
+        Long sessionTokenId = (Long) authentication.getPrincipal();
 
-        if(!userDbManager.passwordChange(userid, form.getNewPassword(), form.getOldPassword())){
+        if(!userDbManager.passwordChange(sessionTokenId, form.getNewPassword(), form.getOldPassword())){
             throw new UserDbAuthenticationException("User has given a mismatching password");
         }
 
+        User user = userDbManager.getBySessionTokenId(sessionTokenId).get();
+        SessionToken st = user.getSessionTokenList().get(0);
+        String jwtToken = jwtTokenCreator(user, st, new ArrayList<GrantedAuthority>(authentication.getAuthorities()));
+
         try {
-            User user = userDbManager.getUserById(userid).get();
             eventPublisher.publishEvent(new SuccessfulPasswordResetEvent(user));
         } catch (Exception e) {
             log.debug(e.getMessage());
         }
 
-        return ResponseEntity.ok(SuccesfullResponse.PASSWORDCHANGE);
+        return ResponseEntity.ok(new LoginResponse(jwtToken));
     }
 
     @RequestMapping(value = "/exit", method = RequestMethod.GET)

--- a/src/main/lombok/eu/coinform/gateway/controller/UserController.java
+++ b/src/main/lombok/eu/coinform/gateway/controller/UserController.java
@@ -110,9 +110,7 @@ public class UserController {
         cookie.setHttpOnly(true);
         cookie.setMaxAge(RENEWAL_TOKEN_MAXAGE);
         cookie.setPath("/renew-token");
-        if (secureCookie) {
-            cookie.setSecure(true);
-        }
+        cookie.setSecure(secureCookie);
         response.addCookie(cookie);
         return new LoginResponse(token);
     }

--- a/src/main/lombok/eu/coinform/gateway/db/SessionTokenRepository.java
+++ b/src/main/lombok/eu/coinform/gateway/db/SessionTokenRepository.java
@@ -4,11 +4,12 @@ import eu.coinform.gateway.db.entity.SessionToken;
 import eu.coinform.gateway.db.entity.User;
 import org.springframework.data.repository.CrudRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SessionTokenRepository extends CrudRepository<SessionToken, Long> {
 
-    public Optional<SessionToken> findByUser(User user);
+    public Optional<List<SessionToken>> findByUser(User user);
     public Optional<SessionToken> findBySessionToken(String token);
 //    public Boolean existBySessionToken(String sessionToken);
 

--- a/src/main/lombok/eu/coinform/gateway/db/UserDbManager.java
+++ b/src/main/lombok/eu/coinform/gateway/db/UserDbManager.java
@@ -74,19 +74,32 @@ public class UserDbManager {
     }
 
     /**
-     * Change password for the user belonging to the passed userid.
-     * @param userid Long holding the userid
+     * Change password for the user belonging to the passed sessionTokenId.
+     * @param sessionTokenId Long holding the sessionTokenId
      * @param newPassword the new password for the user
      * @param oldPassword the old password that is stored in the database
      * @return true if password successfully changed, otherwise false
      */
 
-    public boolean passwordChange(Long userid, String newPassword, String oldPassword){
-        User user = userRepository.findById(userid).get();
+    public boolean passwordChange(Long sessionTokenId, String newPassword, String oldPassword){
+        User user = sessionTokenRepository.findById(sessionTokenId).get().getUser();
         if(!passwordEncoder.matches(oldPassword, user.getPasswordAuth().getPassword())){
             return false;
         }
         user.getPasswordAuth().setPassword(passwordEncoder.encode(newPassword));
+        List<SessionToken> list = user.getSessionTokenList();
+        log.debug("ST List size before: {}", list.size());
+        for(Iterator<SessionToken> iterator = list.iterator(); iterator.hasNext(); ) {
+            SessionToken st = iterator.next();
+            if(!st.getId().equals(sessionTokenId)) {
+                iterator.remove();
+                sessionTokenRepository.delete(st);
+            } else {
+                st.setCounter(st.getCounter()+1);
+                sessionTokenRepository.save(st);
+            }
+        }
+        user.setSessionTokenList(list);
         userRepository.save(user);
         return true;
     }
@@ -250,7 +263,7 @@ public class UserDbManager {
      * @param user the User for whom to find a SessionToken
      * @return A SessionToken object that corresponds to the User
      */
-    public SessionToken getSessionTokenByUser(User user) {
+    public List<SessionToken> getSessionTokenByUser(User user) {
         return sessionTokenRepository.findByUser(user).get();
     }
 

--- a/src/main/lombok/eu/coinform/gateway/db/UserDbManager.java
+++ b/src/main/lombok/eu/coinform/gateway/db/UserDbManager.java
@@ -88,7 +88,6 @@ public class UserDbManager {
         }
         user.getPasswordAuth().setPassword(passwordEncoder.encode(newPassword));
         List<SessionToken> list = user.getSessionTokenList();
-        log.debug("ST List size before: {}", list.size());
         for(Iterator<SessionToken> iterator = list.iterator(); iterator.hasNext(); ) {
             SessionToken st = iterator.next();
             if(!st.getId().equals(sessionTokenId)) {


### PR DESCRIPTION
/change-password endpoint now does the following:
- changes the users password
- invalidates every sessiontoken connected to the user except the one used for changing the password
- returns a new JWT token to be used as authentication invalidating all other JWTs

This is to invalidate every other session the user might have on other devices.